### PR TITLE
feat: add splash screen in launching

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,27 @@ require('update-electron-app')();
 
 Store.initRenderer();
 
+let splashWindow;
+
+/**
+ * @function createSplash
+ */
+function createSplash() {
+  splashWindow = new BrowserWindow({
+    width: 640,
+    height: 360,
+    center: true,
+    frame: false,
+    show: false,
+  });
+
+  splashWindow.loadFile(path.join(__dirname, 'splash.html'));
+
+  splashWindow.once('ready-to-show', () => {
+    splashWindow.show();
+  });
+}
+
 let mainWindow;
 
 /**
@@ -20,6 +41,7 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
+    show: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
     },
@@ -152,7 +174,17 @@ const template = [
 app.whenReady().then(() => {
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
+
+  createSplash();
   createWindow();
+
+  mainWindow.once('ready-to-show', () => {
+    setTimeout(() => {
+      splashWindow.hide();
+      mainWindow.show();
+      splashWindow.destroy();
+    }, 2000);
+  });
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/src/splash.css
+++ b/src/splash.css
@@ -1,0 +1,16 @@
+html,
+body {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+}
+body {
+  background-size: cover;
+  background-repeat: no-repeat;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+h1 {
+  margin: 0;
+}

--- a/src/splash.html
+++ b/src/splash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ja">
+	<head>
+		<meta charset="UTF-8" />
+		<!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
+		<meta
+			http-equiv="Content-Security-Policy"
+			content="default-src 'self'; script-src 'self';"
+		/>
+		<meta
+			http-equiv="X-Content-Security-Policy"
+			content="default-src 'self'; script-src 'self';"
+		/>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>AviUtl Plugin Manager</title>
+		<link
+			rel="stylesheet"
+			href="../node_modules/bootstrap/dist/css/bootstrap.min.css"
+		/>
+		<link rel="stylesheet" href="main.css" />
+		<link rel="stylesheet" href="splash.css" />
+	</head>
+
+	<body class="bg-dark text-white">
+		<h1>AviUtl Plugin Manager</h1>
+
+		<script src="../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+	</body>
+</html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a splash screen while loading.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->#4

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reduces the frustration of long loading times.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OS: Windows 10 Home
Version: 21H1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
