### PR TITLE
refactor: change to separate 'installedVersion' in config by the type of file they are installed on

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -34,7 +34,7 @@ module.exports = {
         if (filesCount === existCount) {
           replaceText(
             `${program}-installed-version`,
-            store.get('installedVersion.' + program, '未インストール')
+            store.get('installedVersion.core.' + program, '未インストール')
           );
         } else {
           replaceText(
@@ -253,7 +253,7 @@ module.exports = {
     }
 
     if (filesCount === existCount) {
-      store.set('installedVersion.' + program, version);
+      store.set('installedVersion.core.' + program, version);
       this.displayInstalledVersion(instPath);
       btn.innerHTML = 'インストール完了';
     } else {

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -142,7 +142,7 @@ module.exports = {
         type.innerHTML = parsePluginType(plugin.type);
         latestVersion.innerHTML = plugin.latestVersion;
 
-        if (store.has('installedVersion.' + plugin.id)) {
+        if (store.has('installedVersion.plugin.' + plugin.id)) {
           let filesCount = 0;
           let existCount = 0;
           for (const file of plugin.files[0].file) {
@@ -156,7 +156,7 @@ module.exports = {
 
           if (filesCount === existCount) {
             installedVersion.innerHTML = store.get(
-              'installedVersion.' + plugin.id,
+              'installedVersion.plugin.' + plugin.id,
               '未インストール'
             );
           } else {
@@ -335,7 +335,7 @@ module.exports = {
 
     if (filesCount === existCount) {
       store.set(
-        'installedVersion.' + selectedPlugin.id,
+        'installedVersion.plugin.' + selectedPlugin.id,
         selectedPlugin.latestVersion
       );
       this.setPluginsList(instPath);
@@ -423,7 +423,7 @@ module.exports = {
     }
 
     if (filesCount === existCount) {
-      store.delete('installedVersion.' + selectedPlugin.id);
+      store.delete('installedVersion.plugin.' + selectedPlugin.id);
       this.setPluginsList(instPath);
       btn.innerHTML = 'アンインストール完了';
     } else {

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -142,7 +142,7 @@ module.exports = {
         type.innerHTML = parseScriptType(script.type);
         latestVersion.innerHTML = script.latestVersion;
 
-        if (store.has('installedVersion.' + script.id)) {
+        if (store.has('installedVersion.script.' + script.id)) {
           let filesCount = 0;
           let existCount = 0;
           for (const file of script.files[0].file) {
@@ -156,7 +156,7 @@ module.exports = {
 
           if (filesCount === existCount) {
             installedVersion.innerHTML = store.get(
-              'installedVersion.' + script.id,
+              'installedVersion.script.' + script.id,
               '未インストール'
             );
           } else {
@@ -346,7 +346,7 @@ module.exports = {
 
     if (filesCount === existCount) {
       store.set(
-        'installedVersion.' + selectedScript.id,
+        'installedVersion.script.' + selectedScript.id,
         selectedScript.latestVersion
       );
       this.setScriptsList(instPath);
@@ -434,7 +434,7 @@ module.exports = {
     }
 
     if (filesCount === existCount) {
-      store.delete('installedVersion.' + selectedScript.id);
+      store.delete('installedVersion.script.' + selectedScript.id);
       this.setScriptsList(instPath);
       btn.innerHTML = 'アンインストール完了';
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change to separate 'installedVersion' in config by the type of file they are installed on.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->Close #20 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
'installedVersion' in config may conflict.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OS: Windows 10 Home
Version: 21H1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
