### PR TITLE
refactor: change the about page preload from the send/on method to the invoke method

### DIFF
--- a/src/about_preload.js
+++ b/src/about_preload.js
@@ -1,18 +1,13 @@
 const { ipcRenderer } = require('electron');
+const replaceText = require('./lib/replaceText');
 
 window.addEventListener('click', () => {
   window.close();
 });
 
-window.addEventListener('DOMContentLoaded', () => {
-  const replaceText = (selector, text) => {
-    const element = document.getElementById(selector);
-    if (element) element.innerText = text;
-  };
-  ipcRenderer.send('get-app-version');
-  ipcRenderer.on('got-app-version', (event, version) => {
-    replaceText('app-version', version);
-  });
+window.addEventListener('DOMContentLoaded', async () => {
+  const appVersion = await ipcRenderer.invoke('get-app-version');
+  replaceText('app-version', appVersion);
   for (const dependency of ['chrome', 'node', 'electron']) {
     replaceText(`${dependency}-version`, process.versions[dependency]);
   }

--- a/src/main.js
+++ b/src/main.js
@@ -93,8 +93,8 @@ function createBrowser(url) {
   browserWindow.loadURL(url);
 }
 
-ipcMain.on('get-app-version', (event) => {
-  event.sender.send('got-app-version', app.getVersion());
+ipcMain.handle('get-app-version', (event) => {
+  return app.getVersion();
 });
 
 ipcMain.handle('exists-temp-file', (event, relativePath) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the about page preload from the send/on method to the invoke method.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->Close #36 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The send/on method is difficult to use because the return value is hard to understand.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OS: Windows 10 Home
Version: 21H1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
