### PR TITLE
fix(plugin.js): fix handling of folders containing spaces

### DIFF
--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -312,7 +312,9 @@ module.exports = {
           '"' +
           exePath[0][0] +
           '" ' +
-          selectedPlugin.installArg.replace('$instpath', '"' + instPath + '"');
+          selectedPlugin.installArg
+            .replace('"$instpath"', '$instpath')
+            .replace('$instpath', '"' + instPath + '"'); // Prevent double quoting
         execSync(command);
       } else {
         const searchedFiles = searchFiles(unzippedPath);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a fix for the problem that the plugin installer does not work properly when Aviutl is installed in a folder whose path contains spaces. Prevents paths from being enclosed twice in quotation marks.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
