### PR TITLE
fix(plugin.js&script.js): treat a single file as an array

### DIFF
--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -109,6 +109,11 @@ module.exports = {
         };
         // optional (it'll return an object in case it's not valid)
         pluginsInfo = parser.parse(xmlData, options);
+        for (const plugin of pluginsInfo.plugins[0].plugin) {
+          if (typeof plugin.files[0].file === 'string') {
+            plugin.files[0].file = [plugin.files[0].file];
+          }
+        }
       } else {
         throw valid;
       }

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -109,6 +109,11 @@ module.exports = {
         };
         // optional (it'll return an object in case it's not valid)
         scriptsInfo = parser.parse(xmlData, options);
+        for (const script of scriptsInfo.scripts[0].script) {
+          if (typeof script.files[0].file === 'string') {
+            script.files[0].file = [script.files[0].file];
+          }
+        }
       } else {
         throw valid;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an issue where plugins such as シークバー＋ and loudness.auf cannot be installed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This problem is caused by inconsistent data structure when parsing xml, where multiple files belonging to a plugin are parsed into an array, and single files are parsed as variables.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Make sure that シークバー＋ and loudness.auf can be installed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
