### PR TITLE
Feat(plugin&script): work with manually added plugins

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -253,7 +253,7 @@
 							>
 								<thead></thead>
 								<tbody class="list"></tbody>
-								<tbody></tbody>
+								<tbody class="table-secondary"></tbody>
 							</table>
 						</div>
 						<div
@@ -406,7 +406,7 @@
 							>
 								<thead></thead>
 								<tbody class="list"></tbody>
-								<tbody></tbody>
+								<tbody class="table-secondary"></tbody>
 							</table>
 						</div>
 						<div

--- a/src/index.html
+++ b/src/index.html
@@ -253,6 +253,7 @@
 							>
 								<thead></thead>
 								<tbody class="list"></tbody>
+								<tbody></tbody>
 							</table>
 						</div>
 						<div
@@ -405,6 +406,7 @@
 							>
 								<thead></thead>
 								<tbody class="list"></tbody>
+								<tbody></tbody>
 							</table>
 						</div>
 						<div

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -301,7 +301,6 @@ module.exports = {
         installedVersion,
       ] = makeTrFromArray(columns);
       tr.classList.add('plugin-tr');
-      tr.classList.add('table-secondary');
       name.innerHTML = ef;
       overview.innerHTML = '手動で追加されたプラグイン';
       developer.innerHTML = '';

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -311,7 +311,6 @@ module.exports = {
         installedVersion,
       ] = makeTrFromArray(columns);
       tr.classList.add('script-tr');
-      tr.classList.add('table-secondary');
       name.innerHTML = ef;
       overview.innerHTML = '手動で追加されたスクリプト';
       developer.innerHTML = '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Manually added plugins are now shown in the plugin list. The duplicate detection algorithm for plugins has been improved accordingly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
resolves #47

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Sometimes you want to install a plugin that does not exist in the repository.
- People who are already using Aviutl should be able to use APM without reinstalling it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually added plug-ins are displayed in gray.
- Non-installed plugins that have the same files as manually added plugins will be marked as '手動インストール済み'.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
