### PR TITLE
feat: change to manage versions by JSON file in installation directory

### DIFF
--- a/src/lib/apmJson.js
+++ b/src/lib/apmJson.js
@@ -139,6 +139,7 @@ module.exports = {
   addPlugin: function (instPath, plugin) {
     const apmJson = getApmJson(instPath);
     apmJson.plugins[plugin.id] = {
+      id: plugin.id,
       repository: plugin.repo,
       version: plugin.latestVersion,
     };
@@ -166,6 +167,7 @@ module.exports = {
   addScript: function (instPath, script) {
     const apmJson = getApmJson(instPath);
     apmJson.scripts[script.id] = {
+      id: script.id,
       repository: script.repo,
       version: script.latestVersion,
     };

--- a/src/lib/apmJson.js
+++ b/src/lib/apmJson.js
@@ -1,0 +1,186 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+/**
+ * Gets the object parsed from `apm.json`.
+ *
+ * @param {string} instPath - An installation path
+ * @returns {object} An object like `package.json`
+ */
+function getApmJson(instPath) {
+  return fs
+    .readJson(path.join(instPath, 'apm.json'))
+    .then((value) => {
+      if (typeof value === 'object') {
+        return value;
+      } else {
+        throw new Error('Invalid apm.json.');
+      }
+    })
+    .catch((reason) => {
+      return { core: { aviutl: null, exedit: null }, plugins: {}, scripts: {} };
+    });
+}
+
+/**
+ * Sets and save the object to `apm.json`.
+ *
+ * @param {string} instPath - An installation path
+ * @param {object} object - An object to write
+ */
+function setApmJson(instPath, object) {
+  fs.writeJson(path.join(instPath, 'apm.json'), object, { spaces: 2 });
+}
+
+module.exports = {
+  /**
+   * Checks whether `apm.json` has the property.
+   *
+   * @param {string} instPath - An installation path
+   * @param {string} keys - Keys to check existing
+   * @returns {Promise<boolean>} Whether `apm.json` has the property.
+   */
+  has: function (instPath, keys) {
+    if (!keys) return false;
+
+    const keysArray = keys.split('.');
+
+    let object = getApmJson(instPath);
+    for (const [i, key] of keysArray.entries()) {
+      if (Object.prototype.hasOwnProperty.call(object, key)) {
+        object = object[key];
+        if (object === null) {
+          if (i !== keysArray.length - 1) {
+            return false;
+          }
+          break;
+        }
+      } else {
+        return false;
+      }
+    }
+    return true;
+  },
+
+  /**
+   * Gets the value from `apm.json`.
+   *
+   * @param {string} instPath - An installation path
+   * @param {string} keys - Keys to get value
+   * @param {any} defaultValue - A value replaced when the property don't exists.
+   * @returns {Promise<any>} The property selected by key.
+   */
+  get: function (instPath, keys = '', defaultValue = undefined) {
+    const apmJson = getApmJson(instPath);
+
+    if (keys === '') return apmJson;
+    const keyArray = keys.split('.');
+
+    let object = apmJson;
+    for (const [i, key] of keyArray.entries()) {
+      object = object[key];
+
+      if (object === undefined) {
+        break;
+      } else if (object === null) {
+        if (i !== keyArray.length - 1) {
+          object = undefined;
+        }
+        break;
+      }
+    }
+    return object === undefined ? defaultValue : object;
+  },
+
+  /**
+   * Sets the value to `apm.json`.
+   *
+   * @param {string} instPath - An installation path
+   * @param {string} keys - Keys to set value
+   * @param {any} value - A value to set
+   */
+  set: function (instPath, keys, value) {
+    if (!keys) return;
+
+    const keyArray = keys.split('.');
+
+    let object = getApmJson(instPath);
+    for (const [i, key] of keyArray.entries()) {
+      if (i !== keyArray.length - 1) {
+        if (!(typeof object === 'object')) {
+          object[key] = {};
+        }
+        object = object[key];
+      } else {
+        object[key] = value;
+      }
+    }
+  },
+
+  /**
+   * Sets the core version to `apm.json`.
+   *
+   * @param {string} instPath - An installation path
+   * @param {string} program - A name of the program
+   * @param {string} version - A version of the program
+   */
+  setCore: function (instPath, program, version) {
+    const apmJson = getApmJson(instPath);
+    apmJson.core[program] = version;
+    setApmJson(instPath, apmJson);
+  },
+
+  /**
+   * Adds the information of the plugin to `apm.json`.
+   *
+   * @param {string} instPath - An installation path
+   * @param {object} plugin - An information of a plugin
+   */
+  addPlugin: function (instPath, plugin) {
+    const apmJson = getApmJson(instPath);
+    apmJson.plugins[plugin.id] = {
+      repository: plugin.repo,
+      version: plugin.latestVersion,
+    };
+    setApmJson(instPath, apmJson);
+  },
+
+  /**
+   * Removes the information of the plugin from `apm.json`.
+   *
+   * @param {string} instPath - An installation path
+   * @param {object} plugin - An information of a plugin
+   */
+  removePlugin: function (instPath, plugin) {
+    const apmJson = getApmJson(instPath);
+    delete apmJson.plugin[plugin.id];
+    setApmJson(instPath, apmJson);
+  },
+
+  /**
+   * Adds the information of the script to `apm.json`.
+   *
+   * @param {string} instPath - An installation path
+   * @param {object} script - An information of a script
+   */
+  addScript: function (instPath, script) {
+    const apmJson = getApmJson(instPath);
+    apmJson.scripts[script.id] = {
+      repository: script.repo,
+      version: script.latestVersion,
+    };
+    setApmJson(instPath, apmJson);
+  },
+
+  /**
+   * Removes the information of the script from `apm.json`.
+   *
+   * @param {string} instPath - An installation path
+   * @param {object} script - An information of a script
+   */
+  removeScript: function (instPath, script) {
+    const apmJson = getApmJson(instPath);
+    delete apmJson.script[script.id];
+    setApmJson(instPath, apmJson);
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change to manage versions by JSON file in installation directory
Now you can keep your data even if you change the installation path.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->Close #45 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is difficult to use because the version information is reset when the installation path is changed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OS: Windows 10 Home
Version: 21H1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
