### PR TITLE
fix(plugin&script): cannot display the list of plugins

### DIFF
--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -186,9 +186,16 @@ module.exports = {
 
     const getExistingFiles = () => {
       const regex = /^(?!exedit).*\.(auf|aui|auo|auc|aul)$/;
+      const safeReaddirSync = (path, option) => {
+        try {
+          return fs.readdirSync(path, option);
+        } catch (e) {
+          if (e.code === 'ENOENT') return [];
+          else throw e;
+        }
+      };
       const readdir = (dir) =>
-        fs
-          .readdirSync(dir, { withFileTypes: true })
+        safeReaddirSync(dir, { withFileTypes: true })
           .filter((i) => i.isFile() && regex.test(i.name))
           .map((i) => i.name);
       return readdir(instPath).concat(

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -186,15 +186,21 @@ module.exports = {
 
     const getExistingFiles = () => {
       const regex = /^(?!exedit).*\.(anm|obj|cam|tra|scn)$/;
+      const safeReaddirSync = (path, option) => {
+        try {
+          return fs.readdirSync(path, option);
+        } catch (e) {
+          if (e.code === 'ENOENT') return [];
+          else throw e;
+        }
+      };
       const readdir = (dir) =>
-        fs
-          .readdirSync(dir, { withFileTypes: true })
+        safeReaddirSync(dir, { withFileTypes: true })
           .filter((i) => i.isFile() && regex.test(i.name))
           .map((i) => i.name);
       return readdir(instPath).concat(
         readdir(path.join(instPath, 'script')).map((i) => 'script/' + i),
-        fs
-          .readdirSync(path.join(instPath, 'script'), { withFileTypes: true })
+        safeReaddirSync(path.join(instPath, 'script'), { withFileTypes: true })
           .filter((i) => i.isDirectory())
           .map((i) => 'script/' + i.name)
           .flatMap((i) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If you try to get the list of plugins when the plugins folder does not exist yet, an error will occur. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixed a bug introduced by #56.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- The plugin list can be displayed even if the plugin folder does not exist.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
