### PR TITLE
refactor(buttonTransition): change to be able to display all types of buttons

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -193,7 +193,11 @@ module.exports = {
     const enableButton = buttonTransition.loading(btn);
 
     if (!instPath) {
-      buttonTransition.error(btn, 'インストール先フォルダを指定してください。');
+      buttonTransition.message(
+        btn,
+        'インストール先フォルダを指定してください。',
+        'danger'
+      );
       setTimeout(() => {
         enableButton();
       }, 3000);
@@ -201,7 +205,7 @@ module.exports = {
     }
 
     if (!version) {
-      buttonTransition.error(btn, 'バージョンを指定してください。');
+      buttonTransition.message(btn, 'バージョンを指定してください。', 'danger');
       setTimeout(() => {
         enableButton();
       }, 3000);
@@ -243,9 +247,9 @@ module.exports = {
       store.set('installedVersion.core.' + program, version);
       this.displayInstalledVersion(instPath);
 
-      buttonTransition.success(btn, 'インストール完了');
+      buttonTransition.message(btn, 'インストール完了', 'success');
     } else {
-      buttonTransition.error(btn, 'エラーが発生しました。');
+      buttonTransition.message(btn, 'エラーが発生しました。', 'danger');
     }
 
     setTimeout(() => {

--- a/src/lib/buttonTransition.js
+++ b/src/lib/buttonTransition.js
@@ -31,55 +31,34 @@ module.exports = {
   },
 
   /**
-   * Show a success message in the button.
+   * Show a message in the button.
    *
-   * @param {HTMLButtonElement} btn - An element of the button to be
+   * @param {HTMLButtonElement} btn - An element of the button to be changed
    * @param {string} message - A message to be shown
+   * @param {string} type - A type of the button to be changed to
    */
-  success: function (btn, message) {
-    for (const type of buttonTypes) {
-      if (btn.classList.contains('btn-' + type)) {
-        btn.classList.replace('btn-' + type, 'btn-success');
-        setTimeout(() => {
-          btn.classList.replace('btn-success', 'btn-' + type);
-        }, 3000);
-        break;
-      }
+  message: function (btn, message, type = null) {
+    if (type != null) {
+      for (const originalType of buttonTypes) {
+        const btnOriginalType = 'btn-' + originalType;
+        const btnType = 'btn-' + type;
+        if (btn.classList.contains(btnOriginalType)) {
+          btn.classList.replace(btnOriginalType, btnType);
+          setTimeout(() => {
+            btn.classList.replace(btnType, btnOriginalType);
+          }, 3000);
+          break;
+        }
 
-      if (btn.classList.contains('btn-outline-' + type)) {
-        btn.classList.replace('btn-outline-' + type, 'btn-outline-success');
-        setTimeout(() => {
-          btn.classList.replace('btn-outline-success', 'btn-outline-' + type);
-        }, 3000);
-        break;
-      }
-    }
-
-    btn.innerHTML = message;
-  },
-
-  /**
-   * Show a error message in the button.
-   *
-   * @param {HTMLButtonElement} btn - An element of the button to be
-   * @param {string} message - A message to be shown
-   */
-  error: function (btn, message) {
-    for (const type of buttonTypes) {
-      if (btn.classList.contains('btn-' + type)) {
-        btn.classList.replace('btn-' + type, 'btn-danger');
-        setTimeout(() => {
-          btn.classList.replace('btn-danger', 'btn-' + type);
-        }, 3000);
-        break;
-      }
-
-      if (btn.classList.contains('btn-outline-' + type)) {
-        btn.classList.replace('btn-outline-' + type, 'btn-outline-danger');
-        setTimeout(() => {
-          btn.classList.replace('btn-outline-danger', 'btn-outline-' + type);
-        }, 3000);
-        break;
+        const outlineOriginalType = 'btn-outline-' + originalType;
+        const outlineType = 'btn-outline-' + type;
+        if (btn.classList.contains(outlineOriginalType)) {
+          btn.classList.replace(outlineOriginalType, outlineType);
+          setTimeout(() => {
+            btn.classList.replace(outlineType, outlineOriginalType);
+          }, 3000);
+          break;
+        }
       }
     }
 

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -370,7 +370,11 @@ module.exports = {
     const enableButton = buttonTransition.loading(btn);
 
     if (!instPath) {
-      buttonTransition.error(btn, 'インストール先フォルダを指定してください。');
+      buttonTransition.message(
+        btn,
+        'インストール先フォルダを指定してください。',
+        'danger'
+      );
       setTimeout(() => {
         enableButton();
       }, 3000);
@@ -378,7 +382,7 @@ module.exports = {
     }
 
     if (!selectedPlugin) {
-      buttonTransition.error(btn, 'プラグインを選択してください。');
+      buttonTransition.message(btn, 'プラグインを選択してください。', 'danger');
       setTimeout(() => {
         enableButton();
       }, 3000);
@@ -443,7 +447,7 @@ module.exports = {
         }
       }
     } catch (e) {
-      buttonTransition.error(btn, 'エラーが発生しました。');
+      buttonTransition.message(btn, 'エラーが発生しました。', 'danger');
     }
 
     let filesCount = 0;
@@ -467,9 +471,9 @@ module.exports = {
       store.set('installedVersion.plugin', installedPlugins);
       this.setPluginsList(instPath);
 
-      buttonTransition.success(btn, 'インストール完了');
+      buttonTransition.message(btn, 'インストール完了', 'success');
     } else {
-      buttonTransition.error(btn, 'エラーが発生しました。');
+      buttonTransition.message(btn, 'エラーが発生しました。', 'danger');
     }
 
     setTimeout(() => {
@@ -487,7 +491,11 @@ module.exports = {
     const enableButton = buttonTransition.loading(btn);
 
     if (!instPath) {
-      buttonTransition.error(btn, 'インストール先フォルダを指定してください。');
+      buttonTransition.message(
+        btn,
+        'インストール先フォルダを指定してください。',
+        'danger'
+      );
       setTimeout(() => {
         enableButton();
       }, 3000);
@@ -495,7 +503,7 @@ module.exports = {
     }
 
     if (!selectedPlugin) {
-      buttonTransition.error(btn, 'プラグインを選択してください。');
+      buttonTransition.message(btn, 'プラグインを選択してください。', 'danger');
       setTimeout(() => {
         enableButton();
       }, 3000);
@@ -535,9 +543,9 @@ module.exports = {
       );
       this.setPluginsList(instPath);
 
-      buttonTransition.success(btn, 'アンインストール完了');
+      buttonTransition.message(btn, 'アンインストール完了', 'success');
     } else {
-      buttonTransition.error(btn, 'エラーが発生しました。');
+      buttonTransition.message(btn, 'エラーが発生しました。', 'danger');
     }
 
     setTimeout(() => {

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -379,7 +379,11 @@ module.exports = {
     const enableButton = buttonTransition.loading(btn);
 
     if (!instPath) {
-      buttonTransition.error(btn, 'インストール先フォルダを指定してください。');
+      buttonTransition.message(
+        btn,
+        'インストール先フォルダを指定してください。',
+        'danger'
+      );
       setTimeout(() => {
         enableButton();
       }, 3000);
@@ -387,7 +391,7 @@ module.exports = {
     }
 
     if (!selectedScript) {
-      buttonTransition.error(btn, 'プラグインを選択してください。');
+      buttonTransition.message(btn, 'プラグインを選択してください。', 'danger');
       setTimeout(() => {
         enableButton();
       }, 3000);
@@ -461,7 +465,7 @@ module.exports = {
         }
       }
     } catch (e) {
-      buttonTransition.error(btn, 'エラーが発生しました。');
+      buttonTransition.message(btn, 'エラーが発生しました。', 'danger');
     }
 
     let filesCount = 0;
@@ -485,9 +489,9 @@ module.exports = {
       store.set('installedVersion.script', installedScripts);
       this.setScriptsList(instPath);
 
-      buttonTransition.success(btn, 'インストール完了');
+      buttonTransition.message(btn, 'インストール完了', 'success');
     } else {
-      buttonTransition.error(btn, 'エラーが発生しました。');
+      buttonTransition.message(btn, 'エラーが発生しました。', 'danger');
     }
 
     setTimeout(() => {
@@ -505,7 +509,11 @@ module.exports = {
     const enableButton = buttonTransition.loading(btn);
 
     if (!instPath) {
-      buttonTransition.error(btn, 'インストール先フォルダを指定してください。');
+      buttonTransition.message(
+        btn,
+        'インストール先フォルダを指定してください。',
+        'danger'
+      );
       setTimeout(() => {
         enableButton();
       }, 3000);
@@ -513,7 +521,7 @@ module.exports = {
     }
 
     if (!selectedScript) {
-      buttonTransition.error(btn, 'プラグインを選択してください。');
+      buttonTransition.message(btn, 'プラグインを選択してください。', 'danger');
       setTimeout(() => {
         enableButton();
       }, 3000);
@@ -553,9 +561,9 @@ module.exports = {
       );
       this.setScriptsList(instPath);
 
-      buttonTransition.success(btn, 'アンインストール完了');
+      buttonTransition.message(btn, 'アンインストール完了', 'success');
     } else {
-      buttonTransition.error(btn, 'エラーが発生しました。');
+      buttonTransition.message(btn, 'エラーが発生しました。', 'danger');
     }
 
     setTimeout(() => {

--- a/src/setting/setting.js
+++ b/src/setting/setting.js
@@ -58,7 +58,7 @@ module.exports = {
       this.setExtraDataUrl(null, store.get('dataURL.extra'));
     }
 
-    buttonTransition.success(btn, '設定完了');
+    buttonTransition.message(btn, '設定完了', 'success');
     setTimeout(() => {
       enableButton();
     }, 3000);
@@ -135,7 +135,7 @@ module.exports = {
     store.set('dataURL.scripts', scripts);
 
     if (btn !== null) {
-      buttonTransition.success(btn, '設定完了');
+      buttonTransition.message(btn, '設定完了', 'success');
       setTimeout(() => {
         enableButton();
       }, 3000);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change to be able to display all types of buttons.
You can use all types of buttons in Bootstrap when you show a message.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->#70 (Doesn't close it)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OS: Windows 10 Home
Version: 21H1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
