### PR TITLE
fix: fix an error when destroying the browser window

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -201,6 +201,8 @@ ipcMain.handle('open-browser', async (event, url, type) => {
     browserWindow.webContents.session.on(
       'will-download',
       (event, item, webContents) => {
+        if (!browserWindow.isDestroyed()) browserWindow.hide();
+
         const ext = path.extname(item.getFilename());
         const dir = path.join(app.getPath('userData'), 'Data');
         if (ext === '.zip') {
@@ -215,7 +217,6 @@ ipcMain.handle('open-browser', async (event, url, type) => {
           resolve(item.getSavePath());
           browserWindow.destroy();
         });
-        browserWindow.hide();
       }
     );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an error when destroying the browser window.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OS: Windows 10 Home
Version: 21H1

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
