### PR TITLE
feat(unzip): support for lzh files

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -2,7 +2,7 @@ module.exports = {
   packagerConfig: {
     executableName: 'apm',
     asar: {
-      unpackDir: 'node_modules/7zip-bin',
+      unpackDir: '{node_modules/7zip-bin,node_modules/win-7zip}',
     },
     ignore: [
       /^(?!.*node_modules).*\/\.github$/,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "fs-extra": "^10.0.0",
     "list.js": "^2.3.1",
     "node-7z": "^3.0.0",
-    "update-electron-app": "^2.0.1"
+    "update-electron-app": "^2.0.1",
+    "win-7zip": "^0.1.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",

--- a/src/lib/unzip.js
+++ b/src/lib/unzip.js
@@ -2,7 +2,15 @@ const path = require('path');
 const sevenBin = require('7zip-bin');
 const { extractFull } = require('node-7z');
 
-const pathTo7zip = sevenBin.path7za.replace('app.asar', 'app.asar.unpacked');
+// https://github.com/puppeteer/puppeteer/issues/2134#issuecomment-408221446
+const pathTo7zipCross = sevenBin.path7za.replace(
+  'app.asar',
+  'app.asar.unpacked'
+);
+const pathTo7zipWin = require('win-7zip')['7z'].replace(
+  'app.asar',
+  'app.asar.unpacked'
+);
 
 /**
  * Unzips zip archive.
@@ -17,18 +25,18 @@ module.exports = async function (zipPath, encode = 'utf8') {
       return path.resolve(
         path.dirname(zipPath),
         '../',
-        path.basename(zipPath, '.zip')
+        path.basename(zipPath, path.extname(zipPath))
       );
     } else {
       return path.resolve(
         path.dirname(zipPath),
-        path.basename(zipPath, '.zip')
+        path.basename(zipPath, path.extname(zipPath))
       );
     }
   };
   const targetPath = getTargetPath();
   const zipStream = extractFull(zipPath, targetPath, {
-    $bin: pathTo7zip,
+    $bin: process.platform === 'win32' ? pathTo7zipWin : pathTo7zipCross,
     overwrite: 'a',
   });
   return new Promise((resolve) => {

--- a/src/main.js
+++ b/src/main.js
@@ -136,7 +136,7 @@ ipcMain.handle(
     if (isTempData) {
       const directory = path.join(app.getPath('userData'), 'Data/', tempSubDir);
 
-      if (ext === '.zip') {
+      if (['.zip', '.lzh'].includes(ext)) {
         opt.directory = path.join(directory, 'archive');
       } else {
         opt.directory = directory;
@@ -205,7 +205,7 @@ ipcMain.handle('open-browser', async (event, url, type) => {
 
         const ext = path.extname(item.getFilename());
         const dir = path.join(app.getPath('userData'), 'Data');
-        if (ext === '.zip') {
+        if (['.zip', '.lzh'].includes(ext)) {
           item.setSavePath(
             path.join(dir, type, 'archive/', item.getFilename())
           );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6389,6 +6389,11 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
+win-7zip@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/win-7zip/-/win-7zip-0.1.1.tgz#14553f6dc56003d9a172f1fb5c488c7f167ec7de"
+  integrity sha1-FFU/bcVgA9mhcvH7XEiMfxZ+x94=
+
 word-wrap@^1.0.3, word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Supports lzh files in addition to zip files. This makes it possible to install "DirectShow File Reader プラグイン for AviUtl".

**This PR contains commit #88.**

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- You can install the zip plugins.
- You can install the lzh plugins.
- It works not only with `yarn start`, but also with `yarn package`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
