### PR TITLE
fix: add missing await

### DIFF
--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -324,7 +324,7 @@ module.exports = {
         pluginRepo
       );
     }
-    this.setPluginsList(instPath);
+    await this.setPluginsList(instPath);
 
     overlay.classList.remove('show');
     overlay.style.zIndex = -1;
@@ -450,7 +450,7 @@ module.exports = {
 
     if (filesCount === existCount) {
       apmJson.addPlugin(instPath, selectedPlugin);
-      this.setPluginsList(instPath);
+      await this.setPluginsList(instPath);
 
       buttonTransition.message(btn, 'インストール完了', 'success');
     } else {
@@ -508,7 +508,7 @@ module.exports = {
 
     if (filesCount === existCount) {
       apmJson.removePlugin(instPath, selectedPlugin);
-      this.setPluginsList(instPath);
+      await this.setPluginsList(instPath);
 
       buttonTransition.message(btn, 'アンインストール完了', 'success');
     } else {

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -335,7 +335,7 @@ module.exports = {
         scriptRepo
       );
     }
-    this.setScriptsList(instPath);
+    await this.setScriptsList(instPath);
 
     overlay.classList.remove('show');
     overlay.style.zIndex = -1;
@@ -473,7 +473,7 @@ module.exports = {
 
     if (filesCount === existCount) {
       apmJson.addScript(instPath, selectedScript);
-      this.setScriptsList(instPath);
+      await this.setScriptsList(instPath);
 
       buttonTransition.message(btn, 'インストール完了', 'success');
     } else {
@@ -531,7 +531,7 @@ module.exports = {
 
     if (filesCount === existCount) {
       apmJson.removeScript(instPath, selectedScript);
-      this.setScriptsList(instPath);
+      await this.setScriptsList(instPath);
 
       buttonTransition.message(btn, 'アンインストール完了', 'success');
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a fix for the problem that the information of installed plugins is not displayed correctly immediately after installation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Information about installed plugins will be displayed even immediately after installation of the plugin.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
