### PR TITLE
feat(parseXML): automatically generate type

### DIFF
--- a/src/lib/parseXML.js
+++ b/src/lib/parseXML.js
@@ -17,6 +17,19 @@ const defaultKeys = [
   'files',
 ];
 
+const typeForExtention = {
+  '.auf': 'filter',
+  '.aui': 'input',
+  '.auo': 'output',
+  '.auc': 'color',
+  '.aul': 'language',
+  '.anm': 'animation',
+  '.obj': 'object',
+  '.cam': 'camera',
+  '.tra': 'track',
+  '.scn': 'scene',
+};
+
 /**
  * @param {object} parsedData - A object parsed from XML.
  * @returns {Array} An array of files.
@@ -87,15 +100,22 @@ class PackageInfo {
     const keys = defaultKeys.concat('installer', 'installArg');
     for (const key of keys) {
       if (parsedPackage[key]) {
-        if (key === 'type') {
-          this.type = parsedPackage.type[0].split(' ');
-        } else if (key === 'files') {
+        if (key === 'files') {
           this.files = parseFiles(parsedPackage);
         } else {
           this[key] = parsedPackage[key][0];
         }
       }
     }
+    const types = this.files.flatMap((f) => {
+      const extention = path.extname(f.filename);
+      if (extention in typeForExtention) {
+        return [typeForExtention[extention]];
+      } else {
+        return [];
+      }
+    });
+    this.type = [...new Set(types)];
     Object.freeze(this);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Automatically generates the `<type>` contained in xml when xml is loaded.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/hal-shu-sato/apm-data/issues/1

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- The xml file with `<type>` removed can be read.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
