### PR TITLE
refactor: replace the unnecessary innerHTML with innerText for the security

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -130,7 +130,7 @@ module.exports = {
         for (const version of Object.keys(progInfo.releases)) {
           const option = document.createElement('option');
           option.value = version;
-          option.innerHTML =
+          option.innerText =
             version +
             (version.includes('rc') ? '（テスト版）' : '') +
             (version === progInfo.latestVersion ? '（最新版）' : '');

--- a/src/lib/buttonTransition.js
+++ b/src/lib/buttonTransition.js
@@ -62,6 +62,6 @@ module.exports = {
       }
     }
 
-    btn.innerHTML = message;
+    btn.innerText = message;
   },
 };

--- a/src/package/package.js
+++ b/src/package/package.js
@@ -341,12 +341,12 @@ module.exports = {
           }
           tr.classList.add('table-secondary');
         });
-        name.innerHTML = package.info.name;
-        overview.innerHTML = package.info.overview;
-        developer.innerHTML = package.info.developer;
-        type.innerHTML = parsePackageType(package.info.type);
-        latestVersion.innerHTML = package.info.latestVersion;
-        installedVersion.innerHTML = getInstalledVersion(package);
+        name.innerText = package.info.name;
+        overview.innerText = package.info.overview;
+        developer.innerText = package.info.developer;
+        type.innerText = parsePackageType(package.info.type);
+        latestVersion.innerText = package.info.latestVersion;
+        installedVersion.innerText = getInstalledVersion(package);
 
         tbody.appendChild(tr);
       }
@@ -359,7 +359,7 @@ module.exports = {
             tr.dataset.repository === package.repository
           ) {
             installedVersion = tr.getElementsByClassName('installedVersion')[0];
-            installedVersion.innerHTML = getInstalledVersion(package);
+            installedVersion.innerText = getInstalledVersion(package);
           }
         }
       }
@@ -377,12 +377,12 @@ module.exports = {
         installedVersion,
       ] = makeTrFromArray(columns);
       tr.classList.add('package-tr');
-      name.innerHTML = ef;
-      overview.innerHTML = '手動で追加されたファイル';
-      developer.innerHTML = '';
-      type.innerHTML = '';
-      latestVersion.innerHTML = '';
-      installedVersion.innerHTML = '';
+      name.innerText = ef;
+      overview.innerText = '手動で追加されたファイル';
+      developer.innerText = '';
+      type.innerText = '';
+      latestVersion.innerText = '';
+      installedVersion.innerText = '';
       bottomTbody.appendChild(tr);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace the unnecessary `innerHTML` with `innerText` for the security

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`innerHTML` is very strong but this means it has vulnerable.
We must reduce the number of times using `innerHTML`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OS: Windows 10 Home
Version: 21H1

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
