### PR TITLE
feat: add a shortcut to the Start menu

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -6,6 +6,7 @@ const store = new Store();
 const log = require('electron-log');
 const replaceText = require('../lib/replaceText');
 const unzip = require('../lib/unzip');
+const shortcut = require('../lib/shortcut');
 const package = require('../package/package');
 const setting = require('../setting/setting');
 const buttonTransition = require('../lib/buttonTransition');
@@ -91,6 +92,19 @@ async function displayInstalledVersion(instPath) {
     replaceText('core-mod-date', '未取得');
 
     replaceText('core-check-date', '未確認');
+  }
+
+  // Add a shortcut to the Start menu
+  if (process.platform === 'win32') {
+    const appDataPath = await ipcRenderer.invoke('app-get-path', 'appData');
+    const aviutlPath = path.join(instPath, 'aviutl.exe');
+    if (fs.existsSync(aviutlPath)) {
+      shortcut.addAviUtlShortcut(appDataPath, aviutlPath);
+      console.log('add');
+    } else {
+      shortcut.removeAviUtlShortcut(appDataPath);
+      console.log('remove');
+    }
   }
 }
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -32,7 +32,7 @@ async function initCore() {
   if (!store.has('installationPath')) {
     const instPath = await getDefaultPath();
     store.set('installationPath', instPath);
-    fs.mkdir(instPath);
+    if (!fs.existsSync(instPath)) fs.mkdirSync(instPath);
   }
 }
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -100,10 +100,8 @@ async function displayInstalledVersion(instPath) {
     const aviutlPath = path.join(instPath, 'aviutl.exe');
     if (fs.existsSync(aviutlPath)) {
       shortcut.addAviUtlShortcut(appDataPath, aviutlPath);
-      console.log('add');
     } else {
       shortcut.removeAviUtlShortcut(appDataPath);
-      console.log('remove');
     }
   }
 }

--- a/src/lib/shortcut.js
+++ b/src/lib/shortcut.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const { shell } = require('electron');
+const fs = require('fs');
+
+const getShortcutPath = (appDataPath) =>
+  path.join(appDataPath, 'Microsoft/Windows/Start Menu/Programs', 'AviUtl.lnk');
+
+/**
+ * Add a shortcut to the Start menu
+ *
+ * @param {string} appDataPath - The path to AppData
+ * @param {string} targetEXE - The path to aviutl.exe
+ */
+function addAviUtlShortcut(appDataPath, targetEXE) {
+  if (process.platform === 'win32') {
+    shell.writeShortcutLink(getShortcutPath(appDataPath), {
+      target: targetEXE,
+    });
+  }
+}
+
+/**
+ * Remove the shortcut from the Start menu
+ *
+ * @param {string} appDataPath - The path to AppData
+ */
+function removeAviUtlShortcut(appDataPath) {
+  if (
+    process.platform === 'win32' &&
+    fs.existsSync(getShortcutPath(appDataPath))
+  ) {
+    fs.unlinkSync(getShortcutPath(appDataPath));
+  }
+}
+
+/**
+ * Uninstaller for shortcuts. This function MUST be executed before the squirrelCommand is interpreted.
+ *
+ * @param {string} appDataPath - The path to AppData
+ */
+function uninstaller(appDataPath) {
+  if (process.platform === 'win32') {
+    const squirrelCommand = process.argv[1];
+    if (squirrelCommand === '--squirrel-uninstall')
+      removeAviUtlShortcut(appDataPath);
+  }
+}
+
+module.exports = {
+  addAviUtlShortcut,
+  removeAviUtlShortcut,
+  uninstaller,
+};

--- a/src/main.js
+++ b/src/main.js
@@ -283,6 +283,10 @@ ipcMain.handle('change-main-zoom-factor', (event, zoomFactor) => {
   mainWindow.webContents.setZoomFactor(zoomFactor);
 });
 
+ipcMain.handle('app-get-path', (event, name) => {
+  return app.getPath(name);
+});
+
 const template = [
   {
     label: 'apm',

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const { execSync } = require('child_process');
 const getHash = require('./lib/getHash');
+const shortcut = require('./lib/shortcut');
 
 log.catchErrors({
   showDialog: false,
@@ -35,6 +36,7 @@ log.catchErrors({
   },
 });
 
+shortcut.uninstaller(app.getPath('appData'));
 if (require('electron-squirrel-startup')) app.quit();
 
 require('update-electron-app')();

--- a/src/preload.js
+++ b/src/preload.js
@@ -21,8 +21,6 @@ log.catchErrors({
 
 window.addEventListener('DOMContentLoaded', async () => {
   const installationPath = document.getElementById('installation-path');
-  installationPath.value = store.get('installationPath', '');
-
   const checkCoreVersionBtn = document.getElementById('check-core-version');
   const checkPackagesListBtn = document.getElementById('check-packages-list');
   const packagesTableOverlay = document.getElementById(
@@ -32,10 +30,12 @@ window.addEventListener('DOMContentLoaded', async () => {
   // init data
   const firstLaunch = !store.has('dataURL.main');
   setting.initSettings();
+  await core.initCore();
   package.initPackage(
     document.getElementById('install-package'),
     document.getElementById('batch-install-packages')
   );
+  installationPath.value = store.get('installationPath', '');
   if (firstLaunch) {
     await core.checkLatestVersion(checkCoreVersionBtn, installationPath.value);
     await package.checkPackagesList(
@@ -62,7 +62,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   }
 
   // tutorial
-  if (store.get('installationPath', '') === '') {
+  if (firstLaunch) {
     const tutorialAlert = document.getElementById('tutorial-alert');
     tutorialAlert.classList.remove('d-none');
   }

--- a/src/preload.js
+++ b/src/preload.js
@@ -36,14 +36,6 @@ window.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('batch-install-packages')
   );
   installationPath.value = store.get('installationPath', '');
-  if (firstLaunch) {
-    await core.checkLatestVersion(checkCoreVersionBtn, installationPath.value);
-    await package.checkPackagesList(
-      checkPackagesListBtn,
-      packagesTableOverlay,
-      installationPath.value
-    );
-  }
 
   // update data
   const oldCoreMod = new Date(store.get('modDate.core', 0));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a shortcut to aviutl.exe to the Start menu.

**This PR depends on the following PR(s).**
- #196

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When you install other video editing software, you will see a shortcut in the start menu. However, this is not the case with AviUtl. I think this is one of the reasons why beginners find AviUtl difficult to use.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- When you install AviUtl, a shortcut will be created.
- If you select a folder with AviUtl, a shortcut will be created.
- If you select a folder without AviUtl, the shortcut will be removed.
- If you uninstall apm, the shortcut will also be removed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
