### PR TITLE
feat(package.js): support dependency specification by logical OR

### DIFF
--- a/src/package/package.js
+++ b/src/package/package.js
@@ -133,18 +133,26 @@ async function setPackagesList(instPath, minorUpdate = false) {
         return true;
       }
       if (p.info.dependencies) {
+        // Whether there is at least one package that is not installable
         return p.info.dependencies.dependency
-          .map((id) => {
-            if (aviUtlR.test(id)) {
-              return id !== 'aviutl' + aviUtlVer;
-            }
-            if (exeditR.test(id)) {
-              return id !== 'exedit' + exeditVer;
-            }
-            return packages
-              .filter((pp) => pp.id === id)
-              .map((pp) => doNotInstall(pp))
-              .some((e) => e);
+          .map((ids) => {
+            // Whether all ids are not installable
+            return ids
+              .split('|')
+              .map((id) => {
+                if (aviUtlR.test(id)) {
+                  return id !== 'aviutl' + aviUtlVer;
+                }
+                if (exeditR.test(id)) {
+                  return id !== 'exedit' + exeditVer;
+                }
+                // Actually, there is no need to use a list because id is unique
+                return packages
+                  .filter((pp) => pp.id === id)
+                  .map((pp) => doNotInstall(pp))
+                  .some((e) => e);
+              })
+              .every((e) => e);
           })
           .some((e) => e);
       }
@@ -161,7 +169,24 @@ async function setPackagesList(instPath, minorUpdate = false) {
       if (!isInstalled(p)) lists.push(p);
       if (p.info.dependencies) {
         lists.push(
-          ...p.info.dependencies.dependency.flatMap((id) => {
+          ...p.info.dependencies.dependency.flatMap((ids) => {
+            // Whether all ids are detached or not
+            const isDetached = ids
+              .split('|')
+              .map((id) => {
+                if (aviUtlR.test(id) || exeditR.test(id)) return false;
+                // Actually, there is no need to use a list because id is unique
+                return packages
+                  .filter((pp) => pp.id === id)
+                  .map((pp) => detached(pp).length !== 0)
+                  .some((e) => e);
+              })
+              .every((e) => e);
+
+            if (!isDetached) return [];
+
+            // If all id's are detached, perform a list fetch for the first id
+            const id = ids.split('|')[0];
             if (aviUtlR.test(id) || exeditR.test(id)) {
               return [];
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Supports specifying dependencies by logical ORs; by specifying multiple ids in dependency separated by `|`, one of the ids will be required.  This is necessary to correctly specify the dependency packages for ~~CacheText~~, InputPipePlugin and SigContrastFastAviUtl after implementing multiple LSMASHWorks.

This is a breaking change. This PR by itself will not cause any problems, but after the corresponding xml release, the current release of apm will not be able to find the packages it depends on.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
[packages_list.zip](https://github.com/hal-shu-sato/apm/files/7533140/packages_list.zip)
InputPipePlugin included in the attachment depends on multiple LSMASHWorks as follows. It should work the same way no matter which LSMASHWorks is installed.
```
	<package>
		...
		<dependencies>
			<dependency>LSMASHWorks|VFRmaniacLSMASHWorks|HolyWuLSMASHWorks|MrOjiiLSMASHWorks</dependency>
		</dependencies>
		...
	</package>
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
