### PR TITLE
fix: fix for dependency resolution

### DIFF
--- a/src/package/package.js
+++ b/src/package/package.js
@@ -188,7 +188,8 @@ async function setPackagesList(instPath, minorUpdate = false) {
       return false;
     };
     p.doNotInstall = doNotInstall(p);
-
+  });
+  packages.forEach((p) => {
     const isInstalled = (p) =>
       p.installedVersion !== packageUtil.states.installedButBroken &&
       p.installedVersion !== packageUtil.states.notInstalled &&
@@ -214,14 +215,17 @@ async function setPackagesList(instPath, minorUpdate = false) {
 
             if (!isDetached) return [];
 
-            // If all id's are detached, perform a list fetch for the first id
-            const id = ids.split('|')[0];
-            if (aviUtlR.test(id) || exeditR.test(id)) {
-              return [];
+            // If all id's are detached, perform a list fetch for the ids
+            for (const id of ids.split('|')) {
+              if (aviUtlR.test(id) || exeditR.test(id)) {
+                continue;
+              }
+              const ps = packages
+                .filter((pp) => pp.id === id)
+                .flatMap((pp) => detached(pp).filter((p) => !p.doNotInstall));
+              if (ps.length > 0) return ps;
             }
-            return packages
-              .filter((pp) => pp.id === id)
-              .flatMap((pp) => detached(pp));
+            return [];
           })
         );
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In https://github.com/hal-shu-sato/apm-data/pull/70 , `auls/confirmclose` always recommends installing `ePi/aulsMemref`, regardless of the version of exedit installed. This PR determines which plugins it recommends to install based on their dependencies.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/hal-shu-sato/apm-data/pull/70

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
When `auls/confirmclose` is installed
- If you have `exedit0.92` installed, `ePi/aulsMemref` is recommended.
- If you have `exedit0.93rc1` installed, `rikky/aulsPluginsByRikky` is recommended.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
