### PR TITLE
fix(package.js): fix for plugin filtering

### DIFF
--- a/src/package/package.js
+++ b/src/package/package.js
@@ -50,7 +50,7 @@ async function getPackages(instPath) {
  * Sets rows of each package in the table.
  *
  * @param {string} instPath - An installation path.
- * @param {boolean} minorUpdate - Only the version of the installed package is updated.
+ * @param {boolean} minorUpdate - Only the installation status of the package has been updated.
  */
 async function setPackagesList(instPath, minorUpdate = false) {
   const packagesSort = document.getElementById('packages-sort');
@@ -297,6 +297,19 @@ async function setPackagesList(instPath, minorUpdate = false) {
     }
   }
 
+  // update the installedVersion inside the listJS
+  listJS.items.forEach((i) => {
+    const value = i.values();
+    const package = packages.filter(
+      (p) =>
+        p.id === i.elm.dataset.id && p.repository === i.elm.dataset.repository
+    );
+    if (package.length === 0) return;
+    value.installedVersion = package[0].installedVersion;
+    i.values(value);
+  });
+
+  // update the installedVersion in the DOM
   for (const package of packages) {
     for (const li of packagesList.getElementsByTagName('li')) {
       if (
@@ -900,7 +913,6 @@ function listFilter(column, btns, btn) {
     } else if (column === 'installedVersion') {
       const query = btn.dataset.installFilter;
       const getValue = (item) => {
-        console.log(item.values().installedVersion);
         const valueSplit = item.values().installedVersion.split('<br>');
         return valueSplit[valueSplit.length - 1].trim();
       };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Immediately after installing a certain plugin, pressing the "絞り込み>インストール済み" button does not show that plugin. This happens because the installation status inside listJS has not been updated.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It is written in the description.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
