### PR TITLE
Change to use dot-prop to edit apm.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bootstrap": "^5.0.1",
     "bootstrap-dark-5": "^1.1.3",
     "clipboard": "^2.0.8",
+    "dot-prop": "^6.0.1",
     "electron-debug": "^3.2.0",
     "electron-dl": "^3.2.1",
     "electron-log": "^4.4.3",

--- a/src/lib/apmJson.js
+++ b/src/lib/apmJson.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
+const dotProp = require('dot-prop');
 
 /**
  * Gets the object parsed from `apm.json`.
@@ -36,87 +37,47 @@ function setApmJson(instPath, object) {
  * Checks whether `apm.json` has the property.
  *
  * @param {string} instPath - An installation path
- * @param {string} keys - Keys to check existing
+ * @param {string} path - Key to check existing
  * @returns {boolean} Whether `apm.json` has the property.
  */
-function has(instPath, keys) {
-  if (!keys) return false;
-
-  const keysArray = keys.split('.');
-
-  let object = getApmJson(instPath);
-  for (const [i, key] of keysArray.entries()) {
-    if (Object.prototype.hasOwnProperty.call(object, key)) {
-      object = object[key];
-      if (object === null) {
-        if (i !== keysArray.length - 1) {
-          return false;
-        }
-        break;
-      }
-    } else {
-      return false;
-    }
-  }
-  return true;
+function has(instPath, path) {
+  return dotProp.has(getApmJson(instPath), path);
 }
 
 /**
  * Gets the value from `apm.json`.
  *
  * @param {string} instPath - An installation path
- * @param {string} keys - Keys to get value
- * @param {any} defaultValue - A value replaced when the property don't exists.
+ * @param {string} path - Key to get value
+ * @param {any} [defaultValue] - A value replaced when the property don't exists.
  * @returns {any} The property selected by key.
  */
-function get(instPath, keys = '', defaultValue = undefined) {
-  const apmJson = getApmJson(instPath);
-
-  if (keys === '') return apmJson;
-  const keyArray = keys.split('.');
-
-  let object = apmJson;
-  for (const [i, key] of keyArray.entries()) {
-    object = object[key];
-
-    if (object === undefined) {
-      break;
-    } else if (object === null) {
-      if (i !== keyArray.length - 1) {
-        object = undefined;
-      }
-      break;
-    }
-  }
-  return object === undefined ? defaultValue : object;
+function get(instPath, path = '', defaultValue) {
+  return dotProp.get(getApmJson(instPath), path, defaultValue);
 }
 
 /**
  * Sets the value to `apm.json`.
  *
  * @param {string} instPath - An installation path
- * @param {string} keys - Keys to set value
- * @param {any} value - A value to set
+ * @param {string} path - Key to set value
+ * @param {any} [value] - A value to set
  */
-function set(instPath, keys, value = undefined) {
-  if (!keys) return;
+function set(instPath, path, value) {
+  const object = dotProp.set(getApmJson(instPath), path, value);
+  setApmJson(instPath, object);
+}
 
-  const keyArray = keys.split('.');
-
-  const rootObject = getApmJson(instPath);
-  let object = rootObject;
-  for (const [i, key] of keyArray.entries()) {
-    if (i !== keyArray.length - 1) {
-      if (!(typeof object[key] === 'object')) {
-        object[key] = {};
-      }
-      object = object[key];
-    } else {
-      if (value !== undefined) object[key] = value;
-      else delete object[key];
-    }
-  }
-  setApmJson(instPath, rootObject);
+/**
+ * Delete the value from `apm.json`.
+ *
+ * @param {string} instPath - An installation path
+ * @param {string} path - Key to delete value
+ */
+function deleteItem(instPath, path) {
+  const object = getApmJson(instPath);
+  dotProp.delete(object, path);
+  setApmJson(instPath, object);
 }
 
 /**
@@ -151,7 +112,15 @@ function addPackage(instPath, package) {
  * @param {object} package - An information of a package
  */
 function removePackage(instPath, package) {
-  set(instPath, `packages.${package.id}`);
+  deleteItem(instPath, `packages.${package.id}`);
 }
 
-module.exports = { has, get, set, setCore, addPackage, removePackage };
+module.exports = {
+  has,
+  get,
+  set,
+  delete: deleteItem,
+  setCore,
+  addPackage,
+  removePackage,
+};

--- a/src/lib/apmJson.js
+++ b/src/lib/apmJson.js
@@ -17,7 +17,7 @@ function getApmJson(instPath) {
       throw new Error('Invalid apm.json.');
     }
   } catch {
-    return { core: {}, packages: {} };
+    return { dataVersion: '2', core: {}, packages: {} };
   }
 }
 
@@ -69,7 +69,7 @@ function set(instPath, path, value) {
 }
 
 /**
- * Delete the value from `apm.json`.
+ * Deletes the value from `apm.json`.
  *
  * @param {string} instPath - An installation path
  * @param {string} path - Key to delete value

--- a/src/migration/migration1to2.js
+++ b/src/migration/migration1to2.js
@@ -136,10 +136,8 @@ async function byFolder(instPath) {
   // Guard condition
   const jsonPath = path.join(instPath, 'apm.json');
   const jsonExists = fs.existsSync(jsonPath);
-  if (!jsonExists) {
-    apmJson.set(instPath, 'dataVersion', '2');
-    return;
-  }
+  if (!jsonExists) return;
+
   const isVerOne = !apmJson.has(instPath, 'dataVersion');
   if (!isVerOne) return;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactor editing `apm.json`.

- Add dot-prop and change to use it.
- Change to return an object containing the data version on the first get.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All function around `apm.json` works correctly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
