### PR TITLE
fix: fix for unexpected download of convert.json

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -39,16 +39,9 @@ window.addEventListener('DOMContentLoaded', async () => {
   installationPath.value = store.get('installationPath', '');
 
   // update data
-  const oldCoreMod = new Date(store.get('modDate.core', 0));
-  const oldPackagesMod = new Date(store.get('modDate.packages', 0));
   await mod.downloadData();
   const currentMod = await mod.getInfo();
-  if (oldCoreMod.getTime() < currentMod.core.getTime()) {
-    await core.checkLatestVersion(installationPath.value);
-  }
-  if (oldPackagesMod.getTime() < currentMod.packages.getTime()) {
-    await package.checkPackagesList(installationPath.value);
-  }
+
   if (currentMod.convert) {
     const oldConvertMod = new Date(
       apmJson.get(installationPath.value, 'convertMod', 0)
@@ -56,6 +49,15 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (oldConvertMod.getTime() < currentMod.convert.getTime()) {
       await convertId(installationPath.value, currentMod.convert.getTime());
     }
+  }
+  const oldCoreMod = new Date(store.get('modDate.core', 0));
+  const oldPackagesMod = new Date(store.get('modDate.packages', 0));
+
+  if (oldCoreMod.getTime() < currentMod.core.getTime()) {
+    await core.checkLatestVersion(installationPath.value);
+  }
+  if (oldPackagesMod.getTime() < currentMod.packages.getTime()) {
+    await package.checkPackagesList(installationPath.value);
   }
 
   // tutorial


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a fix for an issue where convert.json is downloaded at an unexpected time. if parseXML() downloads convert.json before convertId(), there will be inconsistencies in apmJson.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. add id conversion from easymp4 to easymp4a (and update mod.xml)
2. click the Update Package Data button

Intended behavior
No change in apmJson.

Actual behavior
easymp4a is added to apmJson.

When parseXML is executed in setPackagesList(), the latest convert.json is downloaded from getIdDict. At this time, easymp4a is automatically added to apmJson because there is a file whose integrity matches.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
