### PR TITLE
fix: fix for cache reuse conditions

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -210,7 +210,7 @@ async function checkLatestVersion(instPath) {
     await ipcRenderer.invoke(
       'download',
       setting.getCoreDataUrl(),
-      true,
+      false,
       'core'
     );
     await mod.downloadData();

--- a/src/lib/convertId.js
+++ b/src/lib/convertId.js
@@ -16,7 +16,7 @@ async function getIdDict(update = false) {
     const convertJson = await ipcRenderer.invoke(
       'download',
       dictUrl,
-      true,
+      false,
       'package',
       dictUrl
     );

--- a/src/lib/mod.js
+++ b/src/lib/mod.js
@@ -6,7 +6,7 @@ const parseXML = require('./parseXML');
  * Download mod.xml.
  */
 async function downloadData() {
-  await ipcRenderer.invoke('download', setting.getModDataUrl(), true, '');
+  await ipcRenderer.invoke('download', setting.getModDataUrl(), false, '');
 }
 
 /**

--- a/src/migration/migration1to2.js
+++ b/src/migration/migration1to2.js
@@ -134,7 +134,7 @@ async function byFolder(instPath) {
   await ipcRenderer.invoke(
     'download',
     jsonPath,
-    true,
+    false,
     'migration1to2',
     jsonPath
   );

--- a/src/package/packageUtil.js
+++ b/src/package/packageUtil.js
@@ -116,7 +116,7 @@ async function downloadRepository(packageDataUrls) {
     await ipcRenderer.invoke(
       'download',
       packageRepository,
-      true,
+      false,
       'package',
       packageRepository
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed a bug that caused cache lookups to always fail for paths with hash values appended. This bug was also hiding a bug in main.js:341 (before this commit) where json was not included, but this has been fixed as well.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The download of the xml file takes place at the same time as before. This was confirmed by logging in the ipcMain.handle('download') function.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
