### PR TITLE
feat: partial supoort for archive integrity

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -318,6 +318,30 @@ async function installProgram(btn, program, version, instPath) {
         true,
         'core'
       );
+
+      const integrityForArchive =
+        coreInfo[program].releases[version]?.archiveIntegrity;
+      if (integrityForArchive) {
+        const match = await integrity.verifyFile(
+          archivePath,
+          integrityForArchive
+        );
+        if (!match) {
+          if (btn) {
+            buttonTransition.message(
+              btn,
+              'ダウンロードされたファイルが破損しています。',
+              'danger'
+            );
+            setTimeout(() => {
+              enableButton();
+            }, 3000);
+          }
+          log.error(`The downloaded archive file is corrupt. URL:${url}`);
+          return;
+        }
+      }
+
       const unzippedPath = await unzip(archivePath);
       fs.copySync(unzippedPath, instPath);
 

--- a/src/lib/integrity.js
+++ b/src/lib/integrity.js
@@ -14,25 +14,38 @@ async function checkIntegrity(instPath, integrities) {
 
   let match = true;
   for (const integrity of integrities) {
-    const targetPath = path.join(instPath, integrity.target);
-    if (!fs.existsSync(targetPath)) {
-      match = false;
-      break;
-    }
-
-    let readStream;
-    try {
-      readStream = fs.createReadStream(targetPath);
-      await ssri.checkStream(readStream, integrity.targetIntegrity);
-    } catch {
-      match = false;
-      break;
-    } finally {
-      if (readStream) readStream.destroy();
-    }
+    match =
+      match &&
+      (await verifyFile(
+        path.join(instPath, integrity.target),
+        integrity.targetIntegrity
+      ));
   }
 
   return match;
 }
 
-module.exports = { checkIntegrity };
+/**
+ * Check the integrity of the file.
+ *
+ * @param {string} filePath - An file path.
+ * @param {string} integrity - Integrity of the file.
+ * @returns {Promise<boolean>} Integrities match or don't match.
+ */
+async function verifyFile(filePath, integrity) {
+  if (!fs.existsSync(filePath)) return false;
+
+  let readStream;
+  try {
+    readStream = fs.createReadStream(filePath);
+    await ssri.checkStream(readStream, integrity);
+  } catch {
+    return false;
+  } finally {
+    if (readStream) readStream.destroy();
+  }
+
+  return true;
+}
+
+module.exports = { checkIntegrity, verifyFile };

--- a/src/lib/parseXML.js
+++ b/src/lib/parseXML.js
@@ -115,7 +115,8 @@ class CoreInfo {
       for (const release of parsedCore.releases[0].release) {
         this.releases[release.$version[0]] = {
           url: release.url[0],
-          integrities: release.integrities
+          archiveIntegrity: release?.archiveIntegrity?.[0],
+          integrities: release?.integrities
             ? release.integrities[0].integrity.map((integrity) => {
                 return {
                   target: integrity.$target[0],
@@ -157,7 +158,8 @@ class PackageInfo {
           this.releases = {};
           for (const release of parsedPackage[key][0].release) {
             this.releases[release.$version[0]] = {
-              integrities: release.integrities
+              archiveIntegrity: release?.archiveIntegrity?.[0],
+              integrities: release?.integrities
                 ? release.integrities[0].integrity.map((integrity) => {
                     return {
                       target: integrity.$target[0],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make the parser compatible with archiveIntegrity. Also, add the ability to validate archive files to core.js (not to package.js).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #235

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I will reduce the number of new features added, but I added them because they are necessary for testing the parser.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- You can install AviUtl successfully.
- If you restart apm after deleting apm.json, apm.json will be regenerated as before.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
