### PR TITLE
refactor: add bootstrap icons library

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "7zip-bin": "^5.1.1",
     "bootstrap": "^5.0.1",
     "bootstrap-dark-5": "^1.1.3",
+    "bootstrap-icons": "^1.7.2",
     "clipboard": "^2.0.8",
     "dot-prop": "^6.0.1",
     "electron-debug": "^3.2.0",

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@ main {
   height: calc(100% - 2.625rem);
   overflow-y: auto;
 }
-button.dropdown-item:not(.selected) svg {
+button.dropdown-item:not(.selected) i {
   visibility: hidden;
 }
 #packages-table ul {

--- a/src/index.html
+++ b/src/index.html
@@ -374,7 +374,7 @@
 													class="dropdown-item"
 													type="button"
 												>
-													<i class="bi bi-info-circle"></i>タイプについて
+													<i class="bi bi-info-circle me-1"></i>タイプについて
 												</a>
 											</li>
 											<li><hr class="dropdown-divider" /></li>
@@ -407,8 +407,8 @@
 											</li>
 										</ul>
 									</div>
-									<div class="d-inline-block ms-1">
-										<div class="input-group mb-2">
+									<div class="d-inline-block align-middle mb-2 ms-1">
+										<div class="input-group">
 											<span class="input-group-text">
 												<i class="bi bi-search"></i>
 											</span>

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,10 @@
 			rel="stylesheet"
 			href="../node_modules/bootstrap-dark-5/dist/css/bootstrap-dark.min.css"
 		/>
+		<link
+			rel="stylesheet"
+			href="../node_modules/bootstrap-icons/font/bootstrap-icons.css"
+		/>
 		<link rel="stylesheet" href="main.css" />
 		<link rel="stylesheet" href="index.css" />
 	</head>
@@ -280,19 +284,7 @@
 													type="button"
 													data-type-filter="input"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>入力
+													<i class="bi bi-check"></i>入力
 												</button>
 											</li>
 											<li>
@@ -301,19 +293,7 @@
 													type="button"
 													data-type-filter="output"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>出力
+													<i class="bi bi-check"></i>出力
 												</button>
 											</li>
 											<li>
@@ -322,19 +302,7 @@
 													type="button"
 													data-type-filter="filter"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>フィルター
+													<i class="bi bi-check"></i>フィルター
 												</button>
 											</li>
 											<li>
@@ -343,19 +311,7 @@
 													type="button"
 													data-type-filter="color"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>色変換
+													<i class="bi bi-check"></i>色変換
 												</button>
 											</li>
 											<li>
@@ -364,19 +320,7 @@
 													type="button"
 													data-type-filter="language"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>言語
+													<i class="bi bi-check"></i>言語
 												</button>
 											</li>
 											<li>
@@ -385,19 +329,7 @@
 													type="button"
 													data-type-filter="animation"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>アニメーション効果
+													<i class="bi bi-check"></i>アニメーション効果
 												</button>
 											</li>
 											<li>
@@ -406,19 +338,7 @@
 													type="button"
 													data-type-filter="object"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>カスタムオブジェクト
+													<i class="bi bi-check"></i>カスタムオブジェクト
 												</button>
 											</li>
 											<li>
@@ -427,19 +347,7 @@
 													type="button"
 													data-type-filter="scene"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>シーンチェンジ
+													<i class="bi bi-check"></i>シーンチェンジ
 												</button>
 											</li>
 											<li>
@@ -448,19 +356,7 @@
 													type="button"
 													data-type-filter="camera"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>カメラ制御
+													<i class="bi bi-check"></i>カメラ制御
 												</button>
 											</li>
 											<li>
@@ -469,19 +365,7 @@
 													type="button"
 													data-type-filter="track"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>トラックバー
+													<i class="bi bi-check"></i>トラックバー
 												</button>
 											</li>
 											<li>
@@ -490,23 +374,7 @@
 													class="dropdown-item"
 													type="button"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-info-circle"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"
-														/>
-														<path
-															d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"
-														/>
-													</svg>
-													タイプについて
+													<i class="bi bi-info-circle"></i>タイプについて
 												</a>
 											</li>
 											<li><hr class="dropdown-divider" /></li>
@@ -516,19 +384,7 @@
 													type="button"
 													data-install-filter="true"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>インストール済み
+													<i class="bi bi-check"></i>インストール済み
 												</button>
 											</li>
 											<li>
@@ -537,19 +393,7 @@
 													type="button"
 													data-install-filter="manual"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>手動インストール済み
+													<i class="bi bi-check"></i>手動インストール済み
 												</button>
 											</li>
 											<li>
@@ -558,19 +402,7 @@
 													type="button"
 													data-install-filter="false"
 												>
-													<!-- from Bootstrap Icons -->
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="16"
-														height="16"
-														fill="currentColor"
-														class="bi bi-check"
-														viewBox="0 0 16 16"
-													>
-														<path
-															d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"
-														/></svg
-													>未インストール
+													<i class="bi bi-check"></i>未インストール
 												</button>
 											</li>
 										</ul>
@@ -578,19 +410,7 @@
 									<div class="d-inline-block ms-1">
 										<div class="input-group mb-2">
 											<span class="input-group-text">
-												<!-- from Bootstrap Icons -->
-												<svg
-													xmlns="http://www.w3.org/2000/svg"
-													width="16"
-													height="16"
-													fill="currentColor"
-													class="bi bi-search"
-													viewBox="0 0 16 16"
-												>
-													<path
-														d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"
-													/>
-												</svg>
+												<i class="bi bi-search"></i>
 											</span>
 											<input
 												class="fuzzy-search form-control"

--- a/src/package_maker.html
+++ b/src/package_maker.html
@@ -14,6 +14,10 @@
 			rel="stylesheet"
 			href="../node_modules/bootstrap-dark-5/dist/css/bootstrap-dark.min.css"
 		/>
+		<link
+			rel="stylesheet"
+			href="../node_modules/bootstrap-icons/font/bootstrap-icons.css"
+		/>
 		<link rel="stylesheet" href="main.css" />
 	</head>
 
@@ -268,23 +272,7 @@
 						class="btn btn-copy position-absolute top-0 end-0"
 						data-clipboard-target="#output-xml"
 					>
-						<!-- from Bootstrap Icons -->
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="16"
-							height="16"
-							fill="currentColor"
-							class="bi bi-clipboard"
-							viewBox="0 0 16 16"
-						>
-							<path
-								d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"
-							/>
-							<path
-								d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"
-							/>
-						</svg>
-						<span class="ms-1">Copy</span>
+						<i class="bi bi-clipboard"></i> <span class="ms-1">Copy</span>
 					</button>
 				</div>
 			</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1120,6 +1120,11 @@ bootstrap-dark-5@^1.1.3:
   dependencies:
     bootstrap "^5.1.3"
 
+bootstrap-icons@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.7.2.tgz#4024e081e2c850602552e1fed6451e682d09322a"
+  integrity sha512-NiR2PqC73AQOPdVSu6GJfnk+hN2z6powcistXk1JgPnKuoV2FSdSl26w931Oz9HYbKCcKUSB6ncZTYJAYJl3QQ==
+
 bootstrap@^5.0.1, bootstrap@^5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.3.tgz#ba081b0c130f810fa70900acbc1c6d3c28fa8f34"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
 Reduce code by introducing the bootstrap icons library. To check the increase in installer size, I did a `yarn` and `yarn make` after removing node_modules and the increase in size was 0.7MB (90.6→91.3 MB).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
