### PR TITLE
fix: prevent package overwriting

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -8,6 +8,7 @@ const replaceText = require('../lib/replaceText');
 const unzip = require('../lib/unzip');
 const shortcut = require('../lib/shortcut');
 const package = require('../package/package');
+const packageUtil = require('../package/packageUtil');
 const setting = require('../setting/setting');
 const buttonTransition = require('../lib/buttonTransition');
 const parseXML = require('../lib/parseXML');
@@ -416,8 +417,12 @@ async function batchInstall(instPath) {
       const progInfo = coreInfo[program];
       await installProgram(null, program, progInfo.latestVersion, instPath);
     }
-    const packages = (await package.getPackages(instPath)).filter(
-      (p) => p.info.directURL
+    const allPackages = await package.getPackages(instPath);
+    packageUtil.getPackgesExtra(allPackages, instPath);
+    const packages = allPackages.filter(
+      (p) =>
+        p.info.directURL &&
+        p.installedVersion === packageUtil.states.notInstalled
     );
     for (const packageItem of packages) {
       await package.installPackage(instPath, packageItem, true);

--- a/src/package/package.js
+++ b/src/package/package.js
@@ -95,13 +95,6 @@ async function setPackagesList(instPath, minorUpdate = false) {
       });
   }
 
-  // update the batch installation text
-  const batchInstallElm = document.getElementById('batch-install-packages');
-  batchInstallElm.innerText = packages
-    .filter((p) => p.info.directURL)
-    .map((p) => ' + ' + p.info.name)
-    .join('');
-
   // prepare a package list
   let tmpInstalledPackages;
   let tmpInstalledFiles;
@@ -367,6 +360,24 @@ async function setPackagesList(instPath, minorUpdate = false) {
     packagesList2.appendChild(li);
   }
 
+  // update the batch installation text
+  const batchInstallElm = document.getElementById('batch-install-packages');
+  batchInstallElm.innerHTML = null;
+  packages
+    .filter((p) => p.info.directURL)
+    .flatMap((p) => {
+      if (p.installedVersion !== packageUtil.states.notInstalled) {
+        const pTag = document.createElement('span');
+        pTag.classList.add('text-muted');
+        pTag.innerText = '✔' + p.info.name;
+        return [document.createTextNode(' + '), pTag];
+      } else {
+        return [document.createTextNode(' + ' + p.info.name)];
+      }
+    })
+    .forEach((e) => batchInstallElm.appendChild(e));
+
+  // settings page
   if (store.has('modDate.packages')) {
     const modDate = new Date(store.get('modDate.packages'));
     replaceText('packages-mod-date', modDate.toLocaleString());

--- a/src/package/package.js
+++ b/src/package/package.js
@@ -96,28 +96,8 @@ async function setPackagesList(instPath, minorUpdate = false) {
   }
 
   // prepare a package list
-  let tmpInstalledPackages;
-  let tmpInstalledFiles;
-  let tmpManuallyInstalledFiles;
-  const initLists = () => {
-    tmpInstalledPackages = apmJson.get(instPath, 'packages');
-    tmpInstalledFiles = packageUtil.getInstalledFiles(instPath);
-    tmpManuallyInstalledFiles = packageUtil.getManuallyInstalledFiles(
-      tmpInstalledFiles,
-      tmpInstalledPackages,
-      packages
-    );
-    packages.forEach((p) => {
-      p.installedVersion = packageUtil.getInstalledVersionOfPackage(
-        p,
-        tmpInstalledFiles,
-        tmpManuallyInstalledFiles,
-        tmpInstalledPackages,
-        instPath
-      );
-    });
-  };
-  initLists();
+
+  let manuallyInstalledFiles = packageUtil.getPackgesExtra(packages, instPath);
 
   // guess which packages are installed from integrity
   let modified = false;
@@ -136,9 +116,8 @@ async function setPackagesList(instPath, minorUpdate = false) {
       }
     }
   }
-  if (modified) initLists();
-
-  const manuallyInstalledFiles = tmpManuallyInstalledFiles;
+  if (modified)
+    manuallyInstalledFiles = packageUtil.getPackgesExtra(packages, instPath);
 
   let aviUtlVer = '';
   let exeditVer = '';

--- a/src/package/packageUtil.js
+++ b/src/package/packageUtil.js
@@ -2,6 +2,7 @@ const { ipcRenderer } = require('electron');
 const fs = require('fs-extra');
 const path = require('path');
 const parseXML = require('../lib/parseXML');
+const apmJson = require('../lib/apmJson');
 
 /** Installation state of packages */
 const states = {
@@ -246,12 +247,37 @@ function getInstalledVersionOfPackage(
   return installedVersion;
 }
 
+/**
+ * Updates the installedVersion of the packages given as argument and returns a list of manually installed files
+ *
+ * @param {object[]} packages - A list of object parsed from packages.xml
+ * @param {string} instPath - An installation path
+ * @returns {string[]} List of manually installed files
+ */
+function getPackgesExtra(packages, instPath) {
+  const tmpInstalledPackages = apmJson.get(instPath, 'packages');
+  const tmpInstalledFiles = getInstalledFiles(instPath);
+  const tmpManuallyInstalledFiles = getManuallyInstalledFiles(
+    tmpInstalledFiles,
+    tmpInstalledPackages,
+    packages
+  );
+  packages.forEach((p) => {
+    p.installedVersion = getInstalledVersionOfPackage(
+      p,
+      tmpInstalledFiles,
+      tmpManuallyInstalledFiles,
+      tmpInstalledPackages,
+      instPath
+    );
+  });
+  return tmpManuallyInstalledFiles;
+}
+
 module.exports = {
   states,
   parsePackageType,
   getPackages,
   downloadRepository,
-  getInstalledFiles,
-  getManuallyInstalledFiles,
-  getInstalledVersionOfPackage,
+  getPackgesExtra,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prevents package overwriting by the batch install feature.

After performing a batch installation with MrOjii/LSMASHWorks installed, a total of two installations including pop4bit/LSMASHWorks will be saved in apmJson. This is a problematic situation. This PR is to prevent packages that have already been installed from being installed again.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
**This PR must be released before https://github.com/hal-shu-sato/apm-data/issues/87 is resolved.**


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See the description.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
