### PR TITLE
feat(packages.js): support for non-archived packages

### DIFF
--- a/src/package/package.js
+++ b/src/package/package.js
@@ -489,7 +489,25 @@ async function installPackage(instPath, packageToInstall, direct = false) {
   }
 
   try {
-    const unzippedPath = await unzip(archivePath, installedPackage.id);
+    const getUnzippedPath = async () => {
+      if (['.zip', 'lzh'].includes(path.extname(archivePath))) {
+        return await unzip(archivePath, installedPackage.id);
+      } else {
+        // In this line, path.dirname(archivePath) always refers to the 'Data/package' folder.
+        const newFolder = path.join(
+          path.dirname(archivePath),
+          installedPackage.id
+        );
+        await fs.mkdir(newFolder, { recursive: true });
+        await fs.rename(
+          archivePath,
+          path.join(newFolder, path.basename(archivePath))
+        );
+        return newFolder;
+      }
+    };
+
+    const unzippedPath = await getUnzippedPath();
 
     if (installedPackage.info.installer) {
       const searchFiles = (dirName) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Script authors often distribute their packages as raw, unarchived files, and apm cannot read them.
Example: https://drive.google.com/drive/folders/1axN8BDCSGY3w1YaeUgZ4TjlU7MzwRoGI?usp=sharing

This PR makes such files installable.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #337

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

After setting `packages.xml` in [packages.zip](https://github.com/hal-shu-sato/apm/files/7942927/packages.zip) as "追加データ取得先", you can successfully install "ドカベンの文字エフェクト" that appear in the package list.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
