### PR TITLE
feat(package.js): support for archive integrity

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -333,38 +333,53 @@ async function installProgram(btn, program, version, instPath) {
   const coreInfo = await getCoreInfo();
 
   if (coreInfo) {
-    try {
-      const url = coreInfo[program].releases[version].url;
-      const archivePath = await ipcRenderer.invoke(
-        'download',
-        url,
-        true,
-        'core'
-      );
+    const url = coreInfo[program].releases[version].url;
+    let archivePath = await ipcRenderer.invoke('download', url, true, 'core');
 
-      const integrityForArchive =
-        coreInfo[program].releases[version]?.archiveIntegrity;
-      if (integrityForArchive) {
-        const match = await integrity.verifyFile(
-          archivePath,
-          integrityForArchive
-        );
-        if (!match) {
-          if (btn) {
-            buttonTransition.message(
-              btn,
-              'ダウンロードされたファイルが破損しています。',
-              'danger'
+    const integrityForArchive =
+      coreInfo[program].releases[version]?.archiveIntegrity;
+
+    if (integrityForArchive) {
+      for (;;) {
+        // Verify file integrity
+        if (await integrity.verifyFile(archivePath, integrityForArchive)) {
+          break;
+        } else {
+          const dialogResult = await ipcRenderer.invoke(
+            'open-yes-no-dialog',
+            'エラー',
+            'ダウンロードされたファイルは破損しています。再ダウンロードしますか？'
+          );
+          if (dialogResult) {
+            archivePath = await ipcRenderer.invoke(
+              'download',
+              url,
+              false,
+              'core'
             );
-            setTimeout(() => {
-              enableButton();
-            }, 3000);
+            continue;
+          } else {
+            log.error(`The downloaded archive file is corrupt. URL:${url}`);
+            if (btn) {
+              buttonTransition.message(
+                btn,
+                'ダウンロードされたファイルは破損しています。',
+                'danger'
+              );
+              setTimeout(() => {
+                enableButton();
+              }, 3000);
+              return;
+            } else {
+              // Throw an error if not executed from the UI.
+              throw new Error('The downloaded archive file is corrupt.');
+            }
           }
-          log.error(`The downloaded archive file is corrupt. URL:${url}`);
-          return;
         }
       }
+    }
 
+    try {
       const unzippedPath = await unzip(archivePath);
       fs.copySync(unzippedPath, instPath);
 

--- a/src/main.js
+++ b/src/main.js
@@ -105,6 +105,22 @@ ipcMain.handle('open-err-dialog', async (event, title, message) => {
   });
 });
 
+ipcMain.handle('open-yes-no-dialog', async (event, title, message) => {
+  const win = BrowserWindow.getFocusedWindow();
+  const response = await dialog.showMessageBox(win, {
+    title: title,
+    message: message,
+    type: 'warning',
+    buttons: ['はい', `いいえ`],
+    cancelId: 1,
+  });
+  if (response.response === 0) {
+    return true;
+  } else {
+    return false;
+  }
+});
+
 const allowedHosts = [];
 
 app.on(

--- a/src/package/package.js
+++ b/src/package/package.js
@@ -356,6 +356,32 @@ async function installPackage(instPath, packageToInstall, direct = false) {
       true,
       'package'
     );
+
+    const integrityForArchive =
+      installedPackage.info?.releases[installedPackage.info.latestVersion]
+        ?.archiveIntegrity;
+    if (integrityForArchive) {
+      const match = await integrity.verifyFile(
+        archivePath,
+        integrityForArchive
+      );
+      if (!match) {
+        if (btn) {
+          buttonTransition.message(
+            btn,
+            'ダウンロードされたファイルが破損しています。',
+            'danger'
+          );
+          setTimeout(() => {
+            enableButton();
+          }, 3000);
+        }
+        log.error(
+          `The downloaded archive file is corrupt. URL:${installedPackage.info.directURL}`
+        );
+        return;
+      }
+    }
   } else {
     archivePath = await ipcRenderer.invoke(
       'open-browser',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Check the integrity of the archive for packages that are downloaded directly by the recommended bulk installation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- closes #235 
- closes #245
- closes https://github.com/hal-shu-sato/apm-data/issues/50

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- If you click the recommended bulk install button, the package will be installed as before.
- If you click the recommended bulk install button while the cache file in `AppData` has been changed, the package will not be installed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
