### PR TITLE
feat: support for obsolete flag of files

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -281,7 +281,7 @@ async function changeInstallationPath(instPath) {
   const oldCoreMod = new Date(store.get('modDate.core', 0));
   const oldPackagesMod = new Date(store.get('modDate.packages', 0));
 
-  if (oldScriptsMod.getTime() < currentMod.scripts.getTime()) {
+  if (oldScriptsMod.getTime() < currentMod.scripts?.getTime()) {
     await package.getScriptsList(true, currentMod.scripts.getTime());
   }
   if (oldCoreMod.getTime() < currentMod.core.getTime()) {

--- a/src/lib/parseXML.js
+++ b/src/lib/parseXML.js
@@ -64,6 +64,7 @@ function parseFiles(parsedData) {
       isOptional: false,
       isInstallOnly: false,
       isDirectory: false,
+      isObsolete: false,
       archivePath: null,
     };
     if (typeof file === 'string') {
@@ -74,6 +75,7 @@ function parseFiles(parsedData) {
       if (file.$installOnly)
         tmpFile.isInstallOnly = Boolean(file.$installOnly[0]);
       if (file.$directory) tmpFile.isDirectory = Boolean(file.$directory[0]);
+      if (file.$obsolete) tmpFile.isObsolete = Boolean(file.$obsolete[0]);
       if (file.$archivePath) tmpFile.archivePath = file.$archivePath[0];
     } else {
       continue;
@@ -95,6 +97,7 @@ function parseFilesInverse(parsedData) {
     if (file.isOptional) ret['@_optional'] = true;
     if (file.isInstallOnly) ret['@_installOnly'] = true;
     if (file.isDirectory) ret['@_directory'] = true;
+    if (file.isObsolete) ret['@_obsolete'] = true;
     if (file.archivePath) ret['@_archivePath'] = file.archivePath;
     files.push(ret);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a flag to xml to correctly handle files that are not part of the latest version of the package.

Files with `obsolete = true`:
- Will be removed before installation
- Not copied during installation
- Not included in post-installation success checks

Packages that contain `obsolete = true` files:
- Corruption is not checked when checking installation status.

Also, remove incorrect conditional branch regarding `optional` flag

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/hal-shu-sato/apm-data/issues/123

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- It is possible to correctly update the patch.aul

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
