### PR TITLE
fix: make an installation directory just before installing

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -31,7 +31,6 @@ async function initCore() {
       'aviutl'
     );
     store.set('installationPath', instPath);
-    if (!fs.existsSync(instPath)) fs.mkdirSync(instPath);
   }
 }
 
@@ -266,13 +265,15 @@ async function changeInstallationPath(instPath) {
   await mod.downloadData();
   const currentMod = await mod.getInfo();
 
-  // migration
-  await migration.byFolder(instPath);
+  if (fs.existsSync(instPath)) {
+    // migration
+    await migration.byFolder(instPath);
 
-  if (currentMod.convert) {
-    const oldConvertMod = new Date(apmJson.get(instPath, 'convertMod', 0));
-    if (oldConvertMod.getTime() < currentMod.convert.getTime()) {
-      await convertId(instPath, currentMod.convert.getTime());
+    if (currentMod.convert) {
+      const oldConvertMod = new Date(apmJson.get(instPath, 'convertMod', 0));
+      if (oldConvertMod.getTime() < currentMod.convert.getTime()) {
+        await convertId(instPath, currentMod.convert.getTime());
+      }
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Change to make an installation directory just before installing.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->Fix #388

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- apm started normally.
- apm installed AviUtl, Exedit, plugins, and scripts.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
