### PR TITLE
fix: change not to make apm.json when changing the installation path

### DIFF
--- a/src/lib/apmJson.js
+++ b/src/lib/apmJson.js
@@ -8,6 +8,16 @@ import {
 } from 'dot-prop';
 
 /**
+ * Returns the path of `apm.json`.
+ *
+ * @param {string} instPath - An installation path
+ * @returns {string} The path of `apm.json`
+ */
+function getPath(instPath) {
+  return path.join(instPath, 'apm.json');
+}
+
+/**
  * Gets the object parsed from `apm.json`.
  *
  * @param {string} instPath - An installation path
@@ -15,7 +25,7 @@ import {
  */
 function getApmJson(instPath) {
   try {
-    const value = fs.readJsonSync(path.join(instPath, 'apm.json'));
+    const value = fs.readJsonSync(getPath(instPath));
     if (typeof value === 'object') {
       return value;
     } else {
@@ -33,7 +43,7 @@ function getApmJson(instPath) {
  * @param {object} object - An object to write
  */
 function setApmJson(instPath, object) {
-  fs.writeJsonSync(path.join(instPath, 'apm.json'), object, { spaces: 2 });
+  fs.writeJsonSync(getPath(instPath), object, { spaces: 2 });
 }
 
 // Functions to be exported
@@ -121,6 +131,7 @@ function removePackage(instPath, packageItem) {
 }
 
 const apmJson = {
+  getPath,
   has,
   get,
   set,

--- a/src/migration/migration1to2.js
+++ b/src/migration/migration1to2.js
@@ -120,7 +120,7 @@ async function global() {
  */
 async function byFolder(instPath) {
   // Guard condition
-  const jsonPath = path.join(instPath, 'apm.json');
+  const jsonPath = apmJson.getPath(instPath);
   const jsonExists = fs.existsSync(jsonPath);
   if (!jsonExists) return;
 

--- a/src/renderer/main/core.js
+++ b/src/renderer/main/core.js
@@ -273,7 +273,7 @@ async function changeInstallationPath(instPath) {
     // migration
     await migration1to2.byFolder(instPath);
 
-    if (currentMod.convert) {
+    if (fs.existsSync(apmJson.getPath(instPath)) && currentMod.convert) {
       const oldConvertMod = new Date(apmJson.get(instPath, 'convertMod', 0));
       if (oldConvertMod.getTime() < currentMod.convert.getTime()) {
         await convertId(instPath, currentMod.convert.getTime());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Change not to make `apm.json` when changing the installation path to an empty directory.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
